### PR TITLE
Fix UD-320 Specify GitHub API version in header

### DIFF
--- a/app/scripts/directives/import-github.js
+++ b/app/scripts/directives/import-github.js
@@ -19,30 +19,7 @@
 angular.module('odeskApp')
     .constant('localGitHubToken', 'gitHubToken')
     .constant('gitHubCallbackPage', 'gitHubCallback.html')
-    .factory('gitHubTokenStore', function() {
-        return {
-            setToken: function(token) {
-                localStorage.setItem('gitHubToken', token);
-            },
-            getToken: function() {
-                return localStorage.getItem('gitHubToken');
-            }
-        }
-    }).factory('GitHubTokenInjectorInterceptor', ['$q', 'gitHubTokenStore', function($q, gitHubTokenStore) {
-        return {
-            request: function(config) {
-                if (config.url.indexOf('https://api.github.com') == 0) {
-                    var token = gitHubTokenStore.getToken();
-                    if (token) {
-                        config.headers['Authorization'] = 'token ' + token;
-                    }
-                }
-                return config;
-            }
-        };
-    }]).config(['$httpProvider', function($httpProvider) {
-        $httpProvider.interceptors.push('GitHubTokenInjectorInterceptor');
-    }]).service('utils', function() {
+    .service('utils', function() {
         this.camelCase = function(name) {
             return name.replace(/([\:\-\_]+(.))/g, function(_, separator, letter, offset) {
                 return offset ? letter.toUpperCase() : letter;

--- a/app/scripts/services/git-hub-rest-service.js
+++ b/app/scripts/services/git-hub-rest-service.js
@@ -16,19 +16,44 @@
 'use strict';
 
 angular.module('odeskApp')
-    .factory('GitHub', ['$resource', function($resource) {
-        return {
-            user : function() {
-                return $resource('https://api.github.com/user');
-            },
-            organizations : function() {
-                return $resource('https://api.github.com/user/orgs');
-            },
-            userRepositories : function() {
-                return $resource('https://api.github.com/user/repos', {sort: 'full_name'});
-            },
-            organizationRepositories : function(organizationLogin) {
-                return $resource('https://api.github.com/orgs/:organizationLogin/repos', {organizationLogin: organizationLogin, sort: 'full_name'})
-            }
+  .factory('gitHubTokenStore', function() {
+    return {
+      setToken: function(token) {
+        localStorage.setItem('gitHubToken', token);
+      },
+      getToken: function() {
+        return localStorage.getItem('gitHubToken');
+      }
+    }
+  }).factory('GitHubHeadersInjectorInterceptor', ['$q', 'gitHubTokenStore', function($q, gitHubTokenStore) {
+    return {
+      request: function(config) {
+        if (config.url.indexOf('https://api.github.com') == 0) {
+          config.headers['Accept'] = 'application/vnd.github.v3+json';
+
+          var token = gitHubTokenStore.getToken();
+          if (token) {
+            config.headers['Authorization'] = 'token ' + token;
+          }
         }
-    }]);
+        return config;
+      }
+    };
+  }]).config(['$httpProvider', function($httpProvider) {
+    $httpProvider.interceptors.push('GitHubHeadersInjectorInterceptor');
+  }]).factory('GitHub', ['$resource', function($resource) {
+    return {
+        user : function() {
+          return $resource('https://api.github.com/user');
+        },
+        organizations : function() {
+          return $resource('https://api.github.com/user/orgs');
+        },
+        userRepositories : function() {
+          return $resource('https://api.github.com/user/repos', {sort: 'full_name'});
+        },
+        organizationRepositories : function(organizationLogin) {
+          return $resource('https://api.github.com/orgs/:organizationLogin/repos', {organizationLogin: organizationLogin, sort: 'full_name'})
+        }
+      }
+  }]);


### PR DESCRIPTION
Move part of the HTTP header manipulation and token storage and
injection in git-hub-rest-services.js and add the Accept header with
the application/vnd.github.v3+json value to specify the version of
GitHub API used.