### PR TITLE
Fix UD-330 Set proxy target through command line

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,13 +64,14 @@ module.exports = function (grunt) {
         hostname: '0.0.0.0',
         livereload: false
       },
+     // e.g.: Use grunt serve --codenvy-url=dev.box.com --codenvy-port=80 --no-codenvy-https --codenvy-chg-orig to test with Vagrant
      proxies: [{
        context: ['/api', '/ws', '/datasource', '/java-ca'], // the context of the data service
-       host: 'codenvy.com', // wherever the data service is running
-       port: 443, // the port that the data service is running on
-       https: true,
-       changeOrigin: true,
-       xforward: false
+       host: grunt.option('codenvy-url') || 'codenvy.com', // wherever the data service is running
+       port: grunt.option('codenvy-port') || 443, // the port that the data service is running on
+       https: !grunt.option('no-codenvy-https') && true,
+       changeOrigin: !grunt.option('no-codenvy-chg-orig') && true,
+       xforward: !!grunt.option('codenvy-xforward') || false
     }],
     livereload: {
       options: {
@@ -388,6 +389,12 @@ module.exports = function (grunt) {
     if (target === 'dist') {
       return grunt.task.run(['build', 'connect:dist:keepalive']);
     }
+
+    grunt.log.write('Proxy config:\n'
+        + JSON.stringify(grunt.config.get('connect')['proxies'], null, 2)
+        + '\n'
+        + 'To test with another Codenvy instance, use:\n'
+        + 'grunt serve --codenvy-url=<url> --codenvy-port=<port> --[no-]codenvy-https --[no-]codenvy-chg-orig --[no-]xforward\n');
 
     grunt.task.run([
       'clean:server',


### PR DESCRIPTION
Give the ability to set proxy target through command line arguments
without having to change Gruntfile.js. For instance, you can now type
grunt serve --codenvy-url=dev.box.com --codenvy-port=80
--no-codenvy-https --codenvy-chg-orig to use UD with your local Vagrant
image.