### PR TITLE
Fix UD-328 Allow import of private GitHub repo

### DIFF
--- a/app/partials/templates/projects/newProjectModal.html
+++ b/app/partials/templates/projects/newProjectModal.html
@@ -9,7 +9,7 @@
                 <tab-heading>
                     <span class="tab-title"><i class="import-icon fa fa-github fa-lg"></i> From your GitHub account</span>
                 </tab-heading>
-                <ud-import-github workspaces="newProjectCtrl.workspaces" user="newProjectCtrl.user" new-project-data="newProjectCtrl.newProjectData"></ud-import-github>
+                <ud-import-github workspaces="newProjectCtrl.workspaces" current-user-id="newProjectCtrl.currentUserId" new-project-data="newProjectCtrl.newProjectData"></ud-import-github>
                 <alert ng-repeat="alert in newProjectCtrl.alerts" type="{{alert.type}}" close="newProjectCtrl.closeAlert($index)">
                     {{alert.msg}}
                 </alert>

--- a/app/scripts/directives/import-github.js
+++ b/app/scripts/directives/import-github.js
@@ -188,6 +188,7 @@ angular.module('odeskApp')
                     return false;
                   }
                   gitHubTokenStore.setToken(result.data);
+                  $http({ method: 'POST', url: '/api/github/ssh/generate'});
                   return true;
                 });
               };


### PR DESCRIPTION
SSH key was no uploaded and Codenvy userId was wrong for token
exchange. Now, we upload SSH key to GitHub through Codenvy API when
retrieving token and ensure userId used for talking with Codenvy
GitHub API is the right one.