### PR TITLE
Fix UD-356 Delete then import broken

### DIFF
--- a/app/scripts/controllers/dashboard.js
+++ b/app/scripts/controllers/dashboard.js
@@ -357,10 +357,8 @@ angular.module('odeskApp')
       $scope.deleteProject = function () {
           Project.delete($scope.selected).then(function () {
               $('#warning-project-alert .alert-success').show();
-              $scope.projects = _.without($scope.projects, _.findWhere($scope.projects, $scope.selected));
-              if($scope.projects.length==0){
-                  $scope.isProjectDataFetched = true;
-              }
+              ProjectFactory.fetchProjects($scope.workspaces);
+              $scope.isProjectDataFetched = true;
               $timeout(function () {
                   $('#warning-project').modal('hide');
               }, 1500);


### PR DESCRIPTION
Fix broken link between projects list stored in ProjectFactory and the
one displayed in UI. The link was broken by post filtering made after
delete operation on the project list to hide the project that was just
deleted. Instead, trigger a new projects fetch.