### PR TITLE
Fix UD-341 Match selected GitHub repo to location

### DIFF
--- a/app/scripts/directives/import-github.js
+++ b/app/scripts/directives/import-github.js
@@ -266,6 +266,17 @@ angular.module('odeskApp')
               $scope.checkTokenValidity().then(function() {
                 $scope.loadRepositories();
               });
+              
+              $scope.$watch('newProjectData.source.project.location', function(newValue, oldValue) {
+                var matchRepository = $filter('filter')($scope.gitHubRepositories, function(repository, index) {
+                  return repository.clone_url == newValue;
+                });
+                if (matchRepository) {
+                  $scope.selectedRepository = matchRepository[0];
+                } else {
+                  $scope.selectedRepository = undefined;
+                }
+              });
             },
             templateUrl: 'partials/widgets/importGitHub.html'
           };


### PR DESCRIPTION
When remote URL is changed through field input, either match with one
of the GitHub repositories of the list, or unselect the one selected.