### PR TITLE
UD-549 Make place for the shadow to appear

### DIFF
--- a/src/app/projects/project-details/project-details.styl
+++ b/src/app/projects/project-details/project-details.styl
@@ -6,4 +6,4 @@
   margin 20px
 
 .project-details-content
-  margin 15px
+  padding 15px


### PR DESCRIPTION
The shadow appears provided it doesn't overflow the parent (except when
the parent has overflow:visible)
Adding padding makes the child strictly inside the parent so the shadow
can appear